### PR TITLE
Make runqftasm.sh friendlier for Ubuntu 18.04

### DIFF
--- a/tools/runqftasm.sh
+++ b/tools/runqftasm.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 
+set -e
+
 orig_dir=$(pwd)
 temp_dir=$(mktemp -d)
 
+python3=$(if [ -e "$(which python3)" ]; then echo python3; else echo python; fi)
+
 # Generate the final code
-python ./tools/qftasm/qftasm_pp.py $1 > $temp_dir/tmp.qftasm
+"${python3}" ./tools/qftasm/qftasm_pp.py $1 > $temp_dir/tmp.qftasm
 
 # Run the code
-python ./tools/qftasm/qftasm_interpreter.py $temp_dir/tmp.qftasm
+"${python3}" ./tools/qftasm/qftasm_interpreter.py $temp_dir/tmp.qftasm
 
 rm -rf ${temp_dir}


### PR DESCRIPTION
Also use `set -e` to make it easier to identiy failed commands.